### PR TITLE
Fix match scheme

### DIFF
--- a/bandcamp-tag-importer.user.js
+++ b/bandcamp-tag-importer.user.js
@@ -8,7 +8,7 @@
 // @updateURL    https://raw.github.com/zabe40/musicbrainz-userscripts/main/bandcamp-tag-importer.user.js
 // @downloadURL  https://raw.github.com/zabe40/musicbrainz-userscripts/main/bandcamp-tag-importer.user.js
 // @supportURL   https://github.com/zabe40/musicbrainz-userscripts/issues
-// @match        http*://*.musicbrainz.org/release/*
+// @match        *://*.musicbrainz.org/release/*
 // @connect      bandcamp.com
 // @grant        GM_xmlhttpRequest
 // ==/UserScript==


### PR DESCRIPTION
http* is not a valid scheme but * matches both http and https (and not the other schemes like file, ftp, etc.)

Per Google specs: https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns

Sorry I forgot to bump version.
BTW at the beginning, versions like `2024-01-18` would not work good. `2024-01-18` neither.
You would have to use `2024.1.18` to be sure auto updates work properly in all userscript extensions.